### PR TITLE
add option to hide header and other fixes

### DIFF
--- a/sweet-material-table.html
+++ b/sweet-material-table.html
@@ -385,7 +385,7 @@
         return '';
       },
       _getEndValue: function (start, perPage) {
-        var end = start + perPage;
+        var end = start + perPage - 1;
         if (end > this.total) {
           end = this.total;
         }

--- a/sweet-material-table.html
+++ b/sweet-material-table.html
@@ -234,16 +234,16 @@
         perPage: {
           type: Number,
           notify: true,
-          default: 50
+          value: 50
         },
         start: {
           type: Number,
           notify: true,
-          default: 0
+          value: 0
         },
         total: {
           type: Number,
-          default: 0
+          value: 0
         },
         sortColumn: {
           type: String,


### PR DESCRIPTION
##### One feature:

If you don't want to have a title for your table then the header portion is just a big blank space (see screen).

https://www.dropbox.com/s/0vithq1xb4b1sd2/Screenshot%202015-09-17%2020.26.15.png?dl=0
##### Two fixes:
1. Some properties had `default` values set, which (as far as I can tell) is not a keyword in Polymer. They've been changed to `value`.
2. Off-by-1 pagination bug fixed
