### PR TITLE
Add paper-tooltip to display cell value to handle overflow content (and set text overflow to ellipsis)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "polymer": "^1.1.1",
     "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",
     "paper-menu": "PolymerElements/paper-menu#^1.0.0",
+    "paper-tooltip": "PolymerElements/paper-tooltip#^1.0.0",
     "paper-item": "PolymerElements/paper-item#^1.0.0",
     "icon-icons": "PolymerElements/iron-icons#^1.0.0",
     "paper-menu-button": "PolymerElements/paper-menu-button#~1.0.0",

--- a/sweet-material-table-item.html
+++ b/sweet-material-table-item.html
@@ -1,9 +1,11 @@
 <link rel="import" href="../polymer/polymer.html"/>
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html" />
+<link rel="import" href="../paper-tooltip/paper-tooltip.html" />
 
 <!-- Represents a single item row within a sweet-material-table element -->
 <dom-module id="sweet-material-table-item">
   <template>
+    <paper-tooltip>{{value}}</paper-tooltip>
     <div class="flex" id="value">{{value}}</div>
   </template>
   <script>

--- a/sweet-material-table-styles.html
+++ b/sweet-material-table-styles.html
@@ -300,6 +300,14 @@
       #table #loadingIndicator[active] {
         display: block;
       }
+
+      div.sweet-material-table-item {
+        text-overflow: ellipsis;
+        width: 100%;
+        word-wrap: normal;
+        white-space: nowrap;
+        overflow: hidden;
+      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Hello,

Here is a quick add to display cell value in a paper-tooltip to handle overflow content (and set the css text-overflow to ellipsis).

Tell me if I have to rename the branch, create a ticket, optionalize it with an attribute in `sweet-material-table-item` and your thought about it.

Thank you a lot
