### PR TITLE
Changed 'singleAction' event name to 'single-action'.

### DIFF
--- a/sweet-material-table.html
+++ b/sweet-material-table.html
@@ -540,7 +540,7 @@
       },
       _singleActionClicked: function (e) {
         var actionName = e.currentTarget.action;
-        this.fire('singleAction', {
+        this.fire('single-action', {
           name: actionName,
           index: e.currentTarget.index
         });


### PR DESCRIPTION
Polymer uses "snake-case" instead of "camelCase" for event names.

Currently the following code will not catch "singleAction" events:

``` html
<sweet-material-table on-single-action="_listener" ...></sweet-material-table>
```

This pull request fixes the issue.
